### PR TITLE
Fix alteração de estado

### DIFF
--- a/magento2/Observer/AfterPlaceOrderObserver.php
+++ b/magento2/Observer/AfterPlaceOrderObserver.php
@@ -34,15 +34,21 @@ class AfterPlaceOrderObserver extends AbstractDataAssignObserver
         $orderId = $observer->getEvent()->getOrderIds();
         $order = $this->order->load($orderId);
         $currentState = $order->getState();
+        
+        $pay = $order->getPayment();
+        $method = $pay->getMethodInstance();
+        $methodTitle = $method->getTitle();
 
         $save = false;
-        if ($currentState !== $order::STATE_NEW) {
-            $order->setState($order::STATE_PENDING_PAYMENT);
-            $order->setStatus('pending');
-            $save = true;
-        }
-        if ($save) {
-            $order->save();
+        if($methodTitle == "MB WAY") {
+            if ($currentState !== $order::STATE_NEW) {
+                $order->setState($order::STATE_PENDING_PAYMENT);
+                $order->setStatus('pending');
+                $save = true;
+            }
+            if ($save) {
+                $order->save();
+            }
         }
     }
 }

--- a/magento2/Observer/AfterPlaceOrderObserver.php
+++ b/magento2/Observer/AfterPlaceOrderObserver.php
@@ -40,7 +40,7 @@ class AfterPlaceOrderObserver extends AbstractDataAssignObserver
         $methodTitle = $method->getTitle();
 
         $save = false;
-        if($methodTitle == "MB WAY") {
+        if(stripos($methodTitle, "way") !== FALSE) {
             if ($currentState !== $order::STATE_NEW) {
                 $order->setState($order::STATE_PENDING_PAYMENT);
                 $order->setStatus('pending');


### PR DESCRIPTION
Faz com que a alteração do estado de pagamento apenas seja efectuada se o pagamento for efectuado por MbWay;
Outros métodos de pagamento como o PayPal geram encomenda em estado "processing" o que faria com que estado fosse alterado para "Pending Payment" e causaria conflito com o order flow das encomendas